### PR TITLE
Fix case-sensitivity issue for logrus vendor.

### DIFF
--- a/mongodb/accessor.go
+++ b/mongodb/accessor.go
@@ -1,7 +1,7 @@
 package mongodb
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"gopkg.in/mgo.v2"
 )

--- a/mongodb/middleware.go
+++ b/mongodb/middleware.go
@@ -1,7 +1,7 @@
 package mongodb
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 )
 

--- a/statsd/middleware.go
+++ b/statsd/middleware.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gin-gonic/gin"
 )


### PR DESCRIPTION
See https://github.com/sirupsen/logrus#case-sensitivity

This fixes the error:
```
case-insensitive import collision: "github.com/hellofresh/<redacted>/vendor/github.com/Sirupsen/logrus" and "github.com/<redacted>/vendor/github.com/sirupsen/logrus"
make: *** [build-bin] Error 1
```